### PR TITLE
Add setting to fix compilation issue

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -21,5 +21,8 @@
         "test.ts"
     ],
     "public": false,
-    "license": "MIT"
+    "license": "MIT",
+    "disablesVariants": [
+        "mbcodal"
+    ]
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3848

This PR adds the line `"disablesVariants": ["mbcodal"]` to pxt.json so that it will compile fine when downloading. If downloaded onto a V2, it will display a 927 error.

Currently without this line all downloads are failing