### PR TITLE
disable v2 support

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -6,6 +6,7 @@
         "core": "*",
         "radio": "*"
     },
+    "disablesVariants": ["mbcodal"],
     "files": [
         "README.md",
         "LCD1in8.ts",


### PR DESCRIPTION
When using this on a v1 microbit, pxt attempts to compile for v2 and fails (MicroBitPins.h : file not found). This patch disables v2 support for this version of the extensino, and makes the extension work again on a v1. I understand that another repo is used for v2 now.